### PR TITLE
Fix kanshi compatibility by using output names instead of descriptions

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -195,12 +195,12 @@ int store_config(struct wl_list *outputs) {
     }
 
     if (description_index < MAX_MONITORS_NUM) {
-      descriptions[description_index] = strdup(head->description);
+      descriptions[description_index] = strdup(head->name);
       // write output config in given format
       sprintf(
           outputConfigs[description_index],
-          "output \"%s\" position %d,%d mode %dx%d@%.4f scale %.2f transform %s",
-          head->description, output->x, output->y, output->width,
+          "output %s position %d,%d mode %dx%d@%.4f scale %.2f transform %s",
+          head->name, output->x, output->y, output->width,
           output->height, output->refresh / 1.0e3, output->scale, trans_str);
       description_index++;
     } else {


### PR DESCRIPTION
## Fix kanshi compatibility by using output names instead of descriptions

### Problem
The current implementation writes kanshi configurations using output descriptions like:
```
output "Iiyama North America PL2294H2 1207823601758 (DP-3)" position 840,0 mode 1920x1080@60.0000 scale 1.00 transform 270
```

This causes kanshi to fail with "no profile matched" because the parentheses in the description make it invalid according to kanshi's parsing rules.

### Solution
This PR changes `src/store.c` to use `head->name` (e.g. `DP-3`) instead of `head->description`, generating valid kanshi configurations like:
```
output DP-3 position 840,0 mode 1920x1080@60.0000 scale 1.00 transform 270
```

### Technical Details
According to `kanshi(5)` manual, valid output criteria are:
- Output names (e.g. "DP-1")
- Manufacturer/Model/Serial strings (e.g. "Foocorp ASDF 1234") 

The current output descriptions containing parentheses like `(DP-3)` don't match either format.

### Testing
Before fix: `kanshi` shows "no profile matched"
After fix: `kanshi` shows "applying profile" and works correctly

This resolves the core compatibility issue that prevents the kanshi integration from working.
